### PR TITLE
Switch FloatVectorProperty subtype to COLOR_GAMMA

### DIFF
--- a/HUE/preferences.py
+++ b/HUE/preferences.py
@@ -279,7 +279,7 @@ class HUEPreferences(AddonPreferences):
     # -- Fill defaults --
     default_fill_color: FloatVectorProperty(
         name="Default Color",
-        subtype="COLOR",
+        subtype="COLOR_GAMMA",
         default=(1.0, 1.0, 1.0, 1.0),
         min=0.0,
         max=1.0,
@@ -437,7 +437,7 @@ class HUEPreferences(AddonPreferences):
     # -- Selection defaults --
     default_selection_selected_color: FloatVectorProperty(
         name="Selected Color",
-        subtype="COLOR",
+        subtype="COLOR_GAMMA",
         default=(0.0, 0.8, 1.0, 1.0),
         min=0.0,
         max=1.0,
@@ -445,7 +445,7 @@ class HUEPreferences(AddonPreferences):
     )
     default_selection_unselected_color: FloatVectorProperty(
         name="Unselected Color",
-        subtype="COLOR",
+        subtype="COLOR_GAMMA",
         default=(0.1, 0.1, 0.1, 1.0),
         min=0.0,
         max=1.0,

--- a/HUE/property_groups/color_by_selection_tool_properties.py
+++ b/HUE/property_groups/color_by_selection_tool_properties.py
@@ -10,7 +10,7 @@ class ColorBySelectionToolProperties(PropertyGroup):
     selected_color: FloatVectorProperty(
         name="Selected",
         description="Color applied to selected elements",
-        subtype="COLOR",
+        subtype="COLOR_GAMMA",
         default=(0.0, 0.8, 1.0, 1.0),
         min=0,
         max=1,
@@ -20,7 +20,7 @@ class ColorBySelectionToolProperties(PropertyGroup):
     unselected_color: FloatVectorProperty(
         name="Unselected",
         description="Color applied to unselected elements",
-        subtype="COLOR",
+        subtype="COLOR_GAMMA",
         default=(0.1, 0.1, 0.1, 1.0),
         min=0,
         max=1,

--- a/HUE/property_groups/simple_fill_tool_properties.py
+++ b/HUE/property_groups/simple_fill_tool_properties.py
@@ -12,7 +12,7 @@ class SimpleFillToolProperties(PropertyGroup):
     selected_color: FloatVectorProperty(
         name="Color",
         description="Choose a color",
-        subtype="COLOR",
+        subtype="COLOR_GAMMA",
         default=(1, 1, 1, 1),
         min=0,
         max=1,


### PR DESCRIPTION
Quick fix for #6 

Replace FloatVectorProperty subtype "COLOR" with "COLOR_GAMMA" to enable gamma-correct color handling. Updated properties:
- HUE/preferences.py: default_fill_color, default_selection_selected_color, default_selection_unselected_color
- HUE/property_groups/color_by_selection_tool_properties.py: selected_color, unselected_color
- HUE/property_groups/simple_fill_tool_properties.py: selected_color