### PR TITLE
Save and restore per-face material indices

### DIFF
--- a/HUE/operators/display_vertex_colors.py
+++ b/HUE/operators/display_vertex_colors.py
@@ -114,6 +114,9 @@ def _apply_alpha_display_material_to_active_mesh_object(context):
     obj = context.active_object
 
     if obj is not None and obj.type == "MESH":
+        # Save original per-face material indices before overwriting them
+        obj["hue_saved_material_indices"] = [poly.material_index for poly in obj.data.polygons]
+
         obj.data.materials.append(alpha_display_material)
 
         mat_index = obj.data.materials.find(material_name)
@@ -135,6 +138,14 @@ def _remove_alpha_display_material_from_all_mesh_objects(context):
             for slot in obj.material_slots:
                 if slot.material and slot.material.name == material_name:
                     obj.data.materials.pop(index=obj.material_slots.find(material_name))
+
+                    # Restore original per-face material indices saved before preview was applied
+                    saved = obj.get("hue_saved_material_indices")
+                    if saved is not None:
+                        for poly, idx in zip(obj.data.polygons, saved):
+                            poly.material_index = idx
+                        del obj["hue_saved_material_indices"]
+                    obj.data.update()
                     break
 
 


### PR DESCRIPTION
When applying the alpha display material to the active mesh, save the original per-face material indices to a custom object property ('hue_saved_material_indices'). When removing the preview material, restore those saved indices back onto the mesh polygons, delete the saved property, and update the mesh data. This preserves original per-face material assignments when temporarily overriding materials for the preview.

Attempts to fix #8 